### PR TITLE
Identify non-anonymous users

### DIFF
--- a/App.js
+++ b/App.js
@@ -42,7 +42,7 @@ export default class App extends React.Component {
             "debugMode": true
           };
 
-      let userConfig = { "key": this.state.userKey };
+      let userConfig = { key: this.state.userKey, anonymous: false };
 
       await client.configure(clientConfig, userConfig);
       this.setState({ldClient: client});
@@ -198,7 +198,7 @@ export default class App extends React.Component {
           <View style={styles.button}>
             <Button
               title="Identify"
-              onPress={() => this.identify({key: this.state.userKey, firstName: 'John', lastName: 'Smith', email: 'john.smith@smith.net', isAnonymous: false, privateAttributeNames: ['random'], customAttributes: {'random': 'random'}})}
+              onPress={() => this.identify({key: this.state.userKey, firstName: 'John', lastName: 'Smith', email: 'john.smith@smith.net', anonymous: false, privateAttributeNames: ['random'], customAttributes: {'random': 'random'}})}
             />
           </View>
         </View>


### PR DESCRIPTION
As the default behavior in the iOS SDK sets users to be `anonymous=true`, we should set users to be `anonymous=false` by default. Note that we need to do this in two places -- for the initially identified user and for any user identified by an "Identify" button click.

Previously, we were using the default underlying SDK behavior in the first case and incorrectly setting it in the second case.